### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -41,7 +41,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
         SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
@@ -92,7 +92,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
         SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -41,7 +41,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
         SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
@@ -92,7 +92,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
         SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
Catches up catalog-info.yaml to the GitHub team's actual current name (ingest-fp was renamed to Streams). Opened from a fork since I lack direct write/branch-creation access to this repo.